### PR TITLE
Fix typo in pagination comment

### DIFF
--- a/SimplePagination.js
+++ b/SimplePagination.js
@@ -59,7 +59,7 @@ class Pagination {
         }
         else
         {
-            //Iniciar la paginación y mostar los datos en la tabla.
+            //Iniciar la paginación y mostrar los datos en la tabla.
             this.paginacion()
             this.generarTabla(this.estructura,this.mostrarRegistros[this.indiceActual])
         }


### PR DESCRIPTION
## Summary
- fix a spelling error in `SimplePagination.js`

## Testing
- `grep -n "mostar" -r .`


------
https://chatgpt.com/codex/tasks/task_e_6848c6eac2c48328bb5da29012ad9a87